### PR TITLE
Add CI github workflow

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+
+  nix-build:
+    name: Nix build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: cachix/install-nix-action@v17
+      - name: Build all packages
+        run: nix build -L .#docs
+      # - name: Build devShell
+      #   run: nix build -L '.#devShells.x86_64-linux.hacking-on-purenix' '.#devShells.x86_64-linux.use-purenix'
+


### PR DESCRIPTION
Add a GitHub workflow for running CI.

Currently this only builds the documentation, but hopefully Jonas will be able to easily use it for building the web server as well.
