### PR TITLE
Pull programs.sqlite from channel flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,17 @@
         "type": "github"
       }
     },
+    "nixos-channel": {
+      "locked": {
+        "narHash": "sha256-YaglG8AuhQNyK/1wK6NzTFR1onDQplHI33ZpdXhC2Yo=",
+        "type": "tarball",
+        "url": "https://nixos.org/channels/nixos-22.05/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://nixos.org/channels/nixos-22.05/nixexprs.tar.xz"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1659656350,
@@ -34,6 +45,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nixos-channel": "nixos-channel",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-22.05";
   inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nixos-channel.url = "https://nixos.org/channels/nixos-22.05/nixexprs.tar.xz";
 
   outputs = inputs:
     let
@@ -34,6 +35,7 @@
               pkgs.rlwrap
               pkgs.sqlite
             ];
+            BINPLZ_NIX_PROGRAM_DB = "${inputs.nixos-channel}/programs.sqlite";
           };
           defaultPackage = pkgs.binplz-server;
           packages = {


### PR DESCRIPTION
Technically the program db might not be for the _exact_ same commit as nixpkgs, but I think any drift at this point is negligible, especially if the inputs are always updated in tandem.
On this branch, I'm just setting an environment variable in the devShell, but I have a different branch where I use this to include the appropriate db in the generated image, which is really nice.

I'm very happy with this, and I think we can close #5.

@cdepillabout The nixpkgs pin is to `release-22.05`, but the channel is from `nixos-22.05`. I remember you explaining but I don't remember what the exact differences are. Do we need to align those two?

```
$ echo $BINPLZ_NIX_PROGRAM_DB
/nix/store/qjj6lxdh44k0f7lyib1ynq4hzxc4dapf-source/programs.sqlite
$ nix run . -- --help
Usage: binplz-server [-d|--program-db PATH] [-a|--app-db PATH] [-p|--port INT]

Available options:
  -d,--program-db PATH     Path to the nix program database.
                             Environment variable: BINPLZ_NIX_PROGRAM_DB (/nix/store/qjj6lxdh44k0f7lyib1ynq4hzxc4dapf-source/programs.sqlite)
                             Default: /nix/var/nix/profiles/per-user/root/channels/nixos/programs.sqlite
  -a,--app-db PATH         Path to the application database.
                             Environment variable: BINPLZ_APPLICATION_DB (not set)
                             Default: appdb.sqlite
  -p,--port INT            Port to listen on.
                             Environment variable: BINPLZ_PORT (not set)
                             Default: 8081
  -h,--help                Show this help text
```