### PR TITLE
Stream build logs to stdout and stderr

### DIFF
--- a/server/binplz-server.cabal
+++ b/server/binplz-server.cabal
@@ -24,6 +24,7 @@ extra-doc-files:
 common common-options
   build-depends:
     , aeson
+    , async
     , base                  >=4.9 && <5
     , bytestring
     , containers

--- a/server/binplz-server.cabal
+++ b/server/binplz-server.cabal
@@ -36,6 +36,7 @@ common common-options
     , sqlite-simple
     , text
     , transformers
+    , utf8-string
     , warp
 
   default-language: Haskell2010

--- a/server/src/Lib.hs
+++ b/server/src/Lib.hs
@@ -175,6 +175,8 @@ nixBuild (BinaryTriplet bin pkg sys) = runExceptT $ do
             ( ["build", "nixpkgs#legacyPackages." <> show sys <> ".pkgsStatic." <> unPackageName pkg]
                 -- Don't make a result symlink, just print it to stdout
                 <> ["--no-link", "--print-out-paths"]
+                -- Print build logs to stderr
+                <> ["--print-build-logs"]
                 -- Only allow access to files from NIX_PATH. Derivations can't read files like `/etc/shadow`.
                 <> ["--option", "restrict-eval", "true"]
                 -- Disallow IFD.  Probably not necessary, since Nixpkgs doesn't contain derivations that do IFD, but better to be on the safe side.

--- a/server/src/Lib.hs
+++ b/server/src/Lib.hs
@@ -16,6 +16,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.ByteString.Lazy.Char8 as BSL
+import qualified Data.ByteString.Lazy.UTF8 as UTF8
 import Data.Coerce (coerce)
 import Data.Either (isLeft)
 import Data.Maybe (fromMaybe)
@@ -203,14 +204,14 @@ nixBuild (BinaryTriplet bin pkg sys) = runExceptT $ do
       ]
   case (exit, BSL.lines stdout) of
     (ExitSuccess, [result]) -> do
-      let fullPath = BSL.unpack result </> "bin" </> unBinaryName bin
+      let fullPath = UTF8.toString result </> "bin" </> unBinaryName bin
       liftIO . putStrLn $ "Successfully built " <> fullPath
       fileExists <- liftIO $ Dir.doesFileExist fullPath
       unless fileExists $ throwError "Package did not produce expected binary"
       isExecutable <- liftIO $ Dir.executable <$> Dir.getPermissions fullPath
       unless isExecutable $ throwError "Binary specified by the triplet was not an executable"
       liftIO $ BSL.readFile fullPath
-    _ -> throwError $ unlines ["An error occurred.", "  Exit code: " <> show exit, "  error:" <> BSL.unpack stderr]
+    _ -> throwError $ unlines ["An error occurred.", "  Exit code: " <> show exit, "  error:" <> UTF8.toString stderr]
 
 -- TODO rename name field to binary
 -- TODO maybe we should save (and even index by) store path?


### PR DESCRIPTION
This PR modifies the `nixBuild` function to write the logs to stderr and stdout while the build is in progress.

Closes #24 

This is a draft because I haven't actually tested that the logs are printed correctly

- [x] Ensure that the logs are correctly outputted to their respective handles
- [x] Properly decode UTF8 data before converting to String
- [x] Extract `streamCommand` into separate function
- [x] Support adding a prefix to each line when `tee`-ing to the default handles. 