### PR TITLE
Support for armv7l and aarch64 remote builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,12 +78,14 @@
           };
           nix = {
             distributedBuilds = true;
-            buildMachines = [{
-              hostName = "eu.nixbuild.net";
-              system = "x86_64-linux";
-              maxJobs = 100;
-              supportedFeatures = [ "benchmark" "big-parallel" ];
-            }];
+            buildMachines = builtins.map
+              (system: {
+                inherit system;
+                hostName = "eu.nixbuild.net";
+                maxJobs = 100;
+                supportedFeatures = [ "benchmark" "big-parallel" ];
+              })
+              [ "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
             extraOptions = ''
               experimental-features = nix-command flakes
             '';
@@ -180,7 +182,7 @@
         server-vm = inputs.nixos-generators.nixosGenerate {
           inherit pkgs;
           format = "vm";
-          modules = [ config.global config.qemu ];
+          modules = [ config.global config.qemu config.nixbuild ];
         };
         server-ami = inputs.nixos-generators.nixosGenerate {
           inherit pkgs;

--- a/server/src/Lib.hs
+++ b/server/src/Lib.hs
@@ -43,14 +43,17 @@ newtype PackageName = PackageName {unPackageName :: String}
 data Platform
   = X86_64_Linux
   | AARCH_64_Linux
+  | ARMV7_Linux
 
 instance Show Platform where
   show X86_64_Linux = "x86_64-linux"
   show AARCH_64_Linux = "aarch64-linux"
+  show ARMV7_Linux = "armv7l-linux"
 
 instance FromHttpApiData Platform where
   parseQueryParam "aarch64-linux" = pure AARCH_64_Linux
   parseQueryParam "x86_64-linux" = pure X86_64_Linux
+  parseQueryParam "armv7l-linux" = pure ARMV7_Linux
   parseQueryParam sys = Left $ "Unknown platform: " <> sys
 
 -- | A BinaryTriplet uniquely identifies a binary in nixpkgs.


### PR DESCRIPTION
I confirmed that with this, we can build for `aarch64` and `armv7l`. If you want to test on the QEMU vm, you have to copy over `/root/nixbuild.pem` manually.