### PR TITLE
Add simple logrotate-based logging

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,8 @@
       image-name = "binplz-ami-${system}";
       port = 80;
 
+      binplz-log-dir = "/var/log/binplz";
+
       config = {
         amazon = {
           amazonImage.sizeMB = 4096;
@@ -108,7 +110,8 @@
             script = ''
               ${pkgs.binplz-server}/bin/binplz-server \
                 --port ${builtins.toString port} \
-                --program-db ${programs-db}
+                --program-db ${programs-db} \
+                --log-dir ${binplz-log-dir}
             '';
             serviceConfig = {
               Restart = "always";
@@ -131,6 +134,18 @@
           services = {
             openssh.enable = true;
             openssh.permitRootLogin = "prohibit-password";
+            logrotate = {
+              enable = true;
+              settings.${binplz-log-dir + "/*.log"} = {
+                rotate = -1;
+                size = "16M";
+                compress = true;
+                delaycompress = true;
+                dateext = true;
+                missingok = true;
+                notifempty = true;
+              };
+            };
           };
         };
       };

--- a/server/app/Main.hs
+++ b/server/app/Main.hs
@@ -42,6 +42,18 @@ getConfig = runOptionParser $ \envOption ->
             optShow = show
           }
       )
+    <*> envOption
+      ( Option
+          { optHelp = "Log file directory",
+            optMetaVar = "DIR",
+            optLong = "log-dir",
+            optShort = 'd',
+            optEnvKey = "BINPLZ_LOG_DIR",
+            optReadM = Opt.str,
+            optDefault = "/var/log/binplz",
+            optShow = show
+          }
+      )
 
 main :: IO ()
 main = do

--- a/server/binplz-server.cabal
+++ b/server/binplz-server.cabal
@@ -35,6 +35,7 @@ common common-options
     , servant-server
     , sqlite-simple
     , text
+    , time
     , transformers
     , utf8-string
     , warp


### PR DESCRIPTION
This is the simplest possible way I could think to add useful logging. After every request, write the timestamp, parameters, and result to `/var/log/binplz/requests.log` as a JSON record. A logrotate service compresses and timestamps the file as soon as it grows over 16 MB. I didn't know about logrotate, but it's pretty much exactly what I think we want, at least for now.

- it doesn't rely on third-party services
- it has compression
- it's easy to pass to other tools for analysis

In the future, we could

- Sync rotated logs to S3
- Log every request, not just those to build endpoints, by sitting at the `Application` level
- Provide structured Haskell types for log entries to facilitate parsing

I tried my hand at some of these, but I think there's value in first talking about this simple approach, and then seeing where to take it.